### PR TITLE
fix typo of table-name in last migration

### DIFF
--- a/db/migrate/20120819104219_drop_countries_transcription_information_table.rb
+++ b/db/migrate/20120819104219_drop_countries_transcription_information_table.rb
@@ -1,6 +1,6 @@
 class DropCountriesTranscriptionInformationTable < ActiveRecord::Migration
   def up
-    drop_table :countries_transcription_information
+    drop_table "countries_transcription_informations"
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,11 +45,6 @@ ActiveRecord::Schema.define(:version => 20120819104219) do
     t.datetime "updated_at", :null => false
   end
 
-  create_table "countries_transcription_informations", :id => false, :force => true do |t|
-    t.integer "country_id"
-    t.integer "transcription_information_id"
-  end
-
   create_table "educations", :force => true do |t|
     t.string   "name"
     t.datetime "created_at", :null => false
@@ -112,17 +107,6 @@ ActiveRecord::Schema.define(:version => 20120819104219) do
   add_index "jobs", ["client_id"], :name => "index_jobs_on_client_id"
   add_index "jobs", ["job_status_id"], :name => "index_jobs_on_job_status_id"
   add_index "jobs", ["job_type_id"], :name => "index_jobs_on_job_type_id"
-
-  create_table "jobs_service_partners", :force => true do |t|
-    t.integer  "job_id"
-    t.integer  "service_partner_id"
-    t.boolean  "paid"
-    t.datetime "created_at",         :null => false
-    t.datetime "updated_at",         :null => false
-  end
-
-  add_index "jobs_service_partners", ["job_id"], :name => "index_jobs_service_partners_on_job_id"
-  add_index "jobs_service_partners", ["service_partner_id"], :name => "index_jobs_service_partners_on_service_partner_id"
 
   create_table "languages", :force => true do |t|
     t.string   "name"


### PR DESCRIPTION
just cloned the repo and tried to set it up locally, but the last migration failed ;-)
was just a singular/plural typo. 

migration: 20120819104219_drop_countries_transcription_information_table.rb
-    drop_table :countries_transcription_information
-    drop_table "countries_transcription_informations"
